### PR TITLE
Improve dark theme text readability

### DIFF
--- a/app.py
+++ b/app.py
@@ -403,7 +403,7 @@ def apply_user_preferences() -> None:
         theme_css = """
 [data-testid="stAppViewContainer"] {
     background-color: #0e1117;
-    color: #e7eefc;
+    color: #f4f7ff;
 }
 [data-testid="stSidebar"] {
     background-color: #111827;


### PR DESCRIPTION
## Summary
- brighten the default text color in the dark theme to improve legibility against the dark background

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dd36b53f208323a722e93a7813c898