### PR TITLE
Fix Altair radar chart configuration

### DIFF
--- a/app.py
+++ b/app.py
@@ -4297,7 +4297,7 @@ def display_exam_result(result: Dict[str, object]) -> None:
             radar_df = pd.concat([radar_df, radar_df.iloc[[0]]], ignore_index=True)
             chart = (
                 alt.Chart(radar_df)
-                .mark_line(closed=True)
+                .mark_line()
                 .encode(
                     theta=alt.Theta("category", sort=None),
                     radius=alt.Radius("accuracy", scale=alt.Scale(domain=[0, 1])),


### PR DESCRIPTION
## Summary
- remove the unsupported `closed` argument from the Altair radar chart line mark so it renders correctly

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dd393b98008323984d356875a42f0c