### PR TITLE
Handle missing topic column in stats computation

### DIFF
--- a/app.py
+++ b/app.py
@@ -2830,7 +2830,13 @@ def compute_tricky_vocab_heatmap(
 
 
 def compute_most_improved_topic(attempts: pd.DataFrame, df: pd.DataFrame) -> Optional[Dict[str, object]]:
-    merged = attempts.merge(df[["id", "topic"]], left_on="question_id", right_on="id", how="left")
+    if "topic" not in df.columns:
+        return None
+    merged = attempts.merge(
+        df[["id", "topic"]], left_on="question_id", right_on="id", how="left"
+    )
+    if "topic" not in merged.columns:
+        return None
     merged = merged.dropna(subset=["topic"])
     if merged.empty:
         return None


### PR DESCRIPTION
## Summary
- avoid KeyError in the most improved topic calculation when topic metadata is unavailable
- return no result when the topic column is missing from the source or merged data

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68dd3cbea8d883238f63fae101e1b946