### PR TITLE
Ensure predicted question review status column is migrated during import

### DIFF
--- a/app.py
+++ b/app.py
@@ -1178,6 +1178,26 @@ class DBManager:
         inserted = 0
         updated = 0
         with self.engine.begin() as conn:
+            conn_inspector = inspect(conn)
+            predicted_columns = {
+                col["name"]
+                for col in conn_inspector.get_columns(predicted_questions_table.name)
+            }
+
+            if "review_status" not in predicted_columns:
+                conn.execute(
+                    text(
+                        "ALTER TABLE predicted_questions "
+                        "ADD COLUMN review_status TEXT DEFAULT 'pending'"
+                    )
+                )
+                conn.execute(
+                    text(
+                        "UPDATE predicted_questions SET review_status = 'pending' "
+                        "WHERE review_status IS NULL"
+                    )
+                )
+
             existing_ids: Set[str] = set()
             if ids:
                 existing_ids = set(


### PR DESCRIPTION
## Summary
- ensure the `review_status` column exists before inserting predicted questions
- backfill existing predicted questions with a default `pending` status when the column is created

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68de5531b1708323bd82f992a635050c