### PR TITLE
Retry table loads after schema migrations

### DIFF
--- a/app.py
+++ b/app.py
@@ -1046,9 +1046,19 @@ class DBManager:
         try:
             with self.engine.connect() as conn:
                 df = pd.read_sql(select(table), conn)
-        except OperationalError:
-            column_names = [column.name for column in table.columns]
-            return pd.DataFrame(columns=column_names)
+        except OperationalError as exc:
+            logger.warning(
+                "Load failed for %s due to %s. Running schema migrations and retrying.",
+                table.name,
+                exc,
+            )
+            ensure_schema_migrations(self.engine)
+            try:
+                with self.engine.connect() as conn:
+                    df = pd.read_sql(select(table), conn)
+            except OperationalError:
+                column_names = [column.name for column in table.columns]
+                return pd.DataFrame(columns=column_names)
         return df
 
     def load_predicted_questions(self) -> pd.DataFrame:


### PR DESCRIPTION
## Summary
- ensure database reads retry after schema migrations if an OperationalError is raised

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68de57fcb470832387faf1f7d1084e10