### PR TITLE
Add password gate to data import/export tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,3 +11,12 @@
 - 正常に取り込めたらTF-IDFの再学習や履歴エクスポートを活用する
 
 CSV取り込み手順の動画ガイドはこちら: [https://takken.app/videos/csv-import-guide.mp4](https://takken.app/videos/csv-import-guide.mp4)
+
+## データ入出力画面の管理パスワード設定
+
+設定 > データ入出力では、テンプレートのダウンロードや大量のデータ更新が可能なため、管理パスワードによる保護が必要です。以下のいずれかの方法で `DATA_IO_PASSWORD` を設定してください。
+
+- Streamlit の secrets に `DATA_IO_PASSWORD = "your-password"` を追加する (`.streamlit/secrets.toml` など)。
+- サーバーの環境変数に `DATA_IO_PASSWORD` をセットする（例: `export DATA_IO_PASSWORD="your-password"`）。
+
+アプリ起動後、データ入出力画面の冒頭に表示されるパスワード入力欄に値を入力すると、認証されたセッションでのみダウンロード・インポート・リセット機能が利用できます。パスワードが未設定の場合は画面全体が無効化されるため、運用前に必ず設定してください。


### PR DESCRIPTION
## Summary
- add a helper that reads the DATA_IO_PASSWORD from Streamlit secrets or environment variables
- require a valid password before exposing the data import/export UI and cache auth state per session
- document how to configure the management password in the README

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68de6d1ceeac8323b3d482966cf7cc62