### PR TITLE
Allow data IO access when no password is configured

### DIFF
--- a/app.py
+++ b/app.py
@@ -6052,36 +6052,37 @@ def render_history_export_controls(
 def render_data_io(db: DBManager, parent_nav: str = "設定") -> None:
     render_specialized_header(parent_nav, "データ入出力", "data_io")
     st.subheader("データ入出力")
+    auth_key = "data_io_authenticated"
+    hash_key = "data_io_password_hash"
     expected_password = get_data_io_password()
     if not expected_password:
         st.warning(
             "データ入出力の管理パスワードが設定されていません。"
             "Streamlit の secrets もしくは DATA_IO_PASSWORD 環境変数に値を設定してください。"
         )
-        return
-
-    auth_key = "data_io_authenticated"
-    hash_key = "data_io_password_hash"
-    expected_hash = hashlib.sha256(expected_password.encode("utf-8")).hexdigest()
-    if st.session_state.get(hash_key) != expected_hash:
-        st.session_state[hash_key] = expected_hash
-        st.session_state[auth_key] = False
-
-    if not st.session_state.get(auth_key, False):
-        with st.form("data_io_password", clear_on_submit=True):
-            password_input = st.text_input("データ入出力パスワード", type="password", key="data_io_password_input")
-            submitted = st.form_submit_button("認証")
-
-        if not submitted:
-            st.warning("データ入出力パスワードを入力してください。")
-            return
-        if not password_input:
-            st.warning("データ入出力パスワードを入力してください。")
-            return
-        if password_input != expected_password:
-            st.warning("パスワードが正しくありません。")
-            return
+        st.session_state.pop(hash_key, None)
         st.session_state[auth_key] = True
+    else:
+        expected_hash = hashlib.sha256(expected_password.encode("utf-8")).hexdigest()
+        if st.session_state.get(hash_key) != expected_hash:
+            st.session_state[hash_key] = expected_hash
+            st.session_state[auth_key] = False
+
+        if not st.session_state.get(auth_key, False):
+            with st.form("data_io_password", clear_on_submit=True):
+                password_input = st.text_input("データ入出力パスワード", type="password", key="data_io_password_input")
+                submitted = st.form_submit_button("認証")
+
+            if not submitted:
+                st.warning("データ入出力パスワードを入力してください。")
+                return
+            if not password_input:
+                st.warning("データ入出力パスワードを入力してください。")
+                return
+            if password_input != expected_password:
+                st.warning("パスワードが正しくありません。")
+                return
+            st.session_state[auth_key] = True
 
     timestamp = dt.datetime.now().strftime("%Y%m%d-%H%M%S")
     import_notifications = st.session_state.setdefault("import_notifications", [])


### PR DESCRIPTION
## Summary
- keep the データ入出力 page accessible even when no management password is configured
- clear any stale password hash in the session and skip authentication when no password is set
- retain the existing password form when a password is provided via secrets or environment variables

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68dfa62492108323a926db168a60d5ab