### PR TITLE
Restrict data IO until password unlocked

### DIFF
--- a/app.py
+++ b/app.py
@@ -6061,7 +6061,8 @@ def render_data_io(db: DBManager, parent_nav: str = "設定") -> None:
             "Streamlit の secrets もしくは DATA_IO_PASSWORD 環境変数に値を設定してください。"
         )
         st.session_state.pop(hash_key, None)
-        st.session_state[auth_key] = True
+        st.session_state[auth_key] = False
+        st.stop()
     else:
         expected_hash = hashlib.sha256(expected_password.encode("utf-8")).hexdigest()
         if st.session_state.get(hash_key) != expected_hash:


### PR DESCRIPTION
## Summary
- stop rendering data import/export controls when no data IO password is configured
- leave the data IO tab locked until the configured password is entered

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68dfa886c5248323b3985d8341263b83