### PR TITLE
Add default fallback for data IO password

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,4 +19,6 @@ CSV取り込み手順の動画ガイドはこちら: [https://takken.app/videos/
 - Streamlit の secrets に `DATA_IO_PASSWORD = "your-password"` を追加する (`.streamlit/secrets.toml` など)。
 - サーバーの環境変数に `DATA_IO_PASSWORD` をセットする（例: `export DATA_IO_PASSWORD="your-password"`）。
 
+パスワードを設定しない場合は、アプリが既定値 `12211221` を使用します。運用環境では固有の値に変更してください。
+
 アプリ起動後、データ入出力画面の冒頭に表示されるパスワード入力欄に値を入力すると、認証されたセッションでのみダウンロード・インポート・リセット機能が利用できます。パスワードが未設定の場合は画面全体が無効化されるため、運用前に必ず設定してください。

--- a/app.py
+++ b/app.py
@@ -45,6 +45,7 @@ DB_PATH = DATA_DIR / "takken.db"
 UPLOAD_DIR = DATA_DIR / "uploads"
 REJECT_DIR = DATA_DIR / "rejects"
 OFFLINE_EXPORT_DIR = DATA_DIR / "offline_exports"
+DEFAULT_DATA_IO_PASSWORD = "12211221"
 MAPPING_KIND_QUESTIONS = "questions"
 MAPPING_KIND_ANSWERS = "answers"
 SCHEMA_GUIDE_PATH = Path("docs") / "data_schema.md"
@@ -146,7 +147,11 @@ def get_data_io_password() -> Optional[str]:
         return password
 
     env_value = os.getenv("DATA_IO_PASSWORD")
-    return _normalize(env_value)
+    password = _normalize(env_value)
+    if password:
+        return password
+
+    return DEFAULT_DATA_IO_PASSWORD
 
 
 logger = logging.getLogger(__name__)


### PR DESCRIPTION
## Summary
- add a default data import/export password that falls back to 12211221 when no configuration is provided
- update the README to document the default password and remind operators to override it

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68dfaa7bdc988323a95e881be180efd6