### PR TITLE
Improve dark theme contrast ratios

### DIFF
--- a/app.py
+++ b/app.py
@@ -494,17 +494,17 @@ def build_theme_css(theme: str) -> str:
     color-scheme: dark;
     --takken-color-bg: #1c1c1e;
     --takken-color-bg-sidebar: rgba(28, 28, 30, 0.92);
-    --takken-color-surface: rgba(44, 44, 46, 0.94);
-    --takken-color-surface-elevated: rgba(58, 58, 60, 0.94);
-    --takken-color-border: rgba(255, 255, 255, 0.08);
+    --takken-color-surface: rgba(40, 40, 44, 0.96);
+    --takken-color-surface-elevated: rgba(52, 52, 58, 0.96);
+    --takken-color-border: rgba(255, 255, 255, 0.12);
     --takken-color-text: #f5f5f7;
-    --takken-color-text-secondary: rgba(235, 235, 245, 0.6);
-    --takken-color-text-tertiary: rgba(235, 235, 245, 0.38);
-    --takken-color-accent: #0a84ff;
-    --takken-color-accent-soft: rgba(10, 132, 255, 0.18);
+    --takken-color-text-secondary: #c8cad7;
+    --takken-color-text-tertiary: #aeb1c1;
+    --takken-color-accent: #3395ff;
+    --takken-color-accent-soft: rgba(51, 149, 255, 0.24);
     --takken-color-positive: #30d158;
     --takken-color-negative: #ff453a;
-    --takken-focus-ring: 0 0 0 3px rgba(10, 132, 255, 0.45);
+    --takken-focus-ring: 0 0 0 3px rgba(51, 149, 255, 0.45);
     --takken-shadow-strong: 0 24px 60px rgba(0, 0, 0, 0.55);
     --takken-radius-large: 18px;
 }
@@ -543,11 +543,11 @@ body {
 .stTabs [data-baseweb="tab"][aria-selected="true"] {
     background: var(--takken-color-accent-soft);
     color: var(--takken-color-text);
-    border-color: rgba(10, 132, 255, 0.4);
+    border-color: rgba(51, 149, 255, 0.45);
 }
 .stTabs [data-baseweb="tab"]:hover {
     color: var(--takken-color-text);
-    border-color: rgba(10, 132, 255, 0.25);
+    border-color: rgba(51, 149, 255, 0.32);
 }
 .stMetric,
 .stAlert,
@@ -569,9 +569,9 @@ body {
     padding: 1.1rem 1.2rem;
 }
 .home-dropzone-card {
-    background: rgba(10, 132, 255, 0.12);
-    border: 1px solid rgba(10, 132, 255, 0.48);
-    box-shadow: 0 22px 60px rgba(10, 132, 255, 0.25);
+    background: rgba(51, 149, 255, 0.16);
+    border: 1px solid rgba(51, 149, 255, 0.5);
+    box-shadow: 0 22px 60px rgba(51, 149, 255, 0.3);
 }
 .home-data-card {
     background: var(--takken-color-surface);
@@ -580,18 +580,18 @@ body {
 }
 .takken-choice-button button,
 .stButton > button {
-    background: linear-gradient(135deg, #0a84ff 0%, #64d2ff 100%);
+    background: linear-gradient(135deg, #3395ff 0%, #7dd4ff 100%);
     color: #ffffff;
     border: none;
     border-radius: 14px;
     font-weight: 600;
-    box-shadow: 0 16px 40px rgba(10, 132, 255, 0.28);
+    box-shadow: 0 16px 40px rgba(51, 149, 255, 0.34);
     transition: transform 0.2s ease, box-shadow 0.2s ease, background 0.3s ease;
 }
 .takken-choice-button button:hover,
 .stButton > button:hover {
     transform: translateY(-1px);
-    box-shadow: 0 20px 48px rgba(10, 132, 255, 0.38);
+    box-shadow: 0 20px 48px rgba(51, 149, 255, 0.42);
 }
 .takken-choice-button button:focus,
 .stButton > button:focus {
@@ -641,7 +641,7 @@ label, legend {
     color: var(--takken-color-text-secondary);
 }
 code, pre {
-    background: rgba(44, 44, 46, 0.9);
+    background: rgba(40, 40, 44, 0.9);
     color: var(--takken-color-text);
     border-radius: 12px;
     border: 1px solid var(--takken-color-border);
@@ -665,7 +665,7 @@ code, pre {
     background: var(--takken-color-accent);
 }
 .stProgress > div {
-    background: rgba(10, 132, 255, 0.12);
+    background: rgba(51, 149, 255, 0.16);
 }
 .stSlider > div > div > div[data-baseweb="slider"] > div:first-child {
     background: rgba(255, 255, 255, 0.08);
@@ -689,7 +689,7 @@ code, pre {
     color: var(--takken-color-text-secondary);
 }
 hr {
-    border-color: rgba(255, 255, 255, 0.08);
+    border-color: var(--takken-color-border);
 }
 """
     if theme == "セピア":


### PR DESCRIPTION
## Summary
- raise dark theme secondary and tertiary text tokens to meet WCAG AA contrast requirements
- deepen surface layers and refresh accent/focus colors so controls and cards maintain legibility
- align dropzone, progress, and button treatments with the updated palette for a consistent UI

## Testing
- pytest
- streamlit run app.py --server.headless true --server.port 8501

------
https://chatgpt.com/codex/tasks/task_e_68e0c3de49508323b96bf291d4de3df6