### PR TITLE
Add tests and CI with ruff linting

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,31 @@
+name: CI
+
+on:
+  push:
+    branches:
+      - "**"
+  pull_request:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: "3.11"
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt
+
+      - name: Run ruff
+        run: ruff check .
+
+      - name: Run pytest
+        run: pytest

--- a/README.md
+++ b/README.md
@@ -12,6 +12,22 @@
 
 CSV取り込み手順の動画ガイドはこちら: [https://takken.app/videos/csv-import-guide.mp4](https://takken.app/videos/csv-import-guide.mp4)
 
+## 開発者向けチェック
+
+GitHub Actions の [CI ワークフロー](.github/workflows/ci.yml) は、以下の順序で品質チェックを実行します。
+
+1. `requirements.txt` の依存関係をインストール
+2. `ruff check .` による静的解析
+3. `pytest` によるユニットテスト
+
+同じ手順をローカルで再現する場合は、次のコマンドを実行してください。
+
+```bash
+pip install -r requirements.txt
+ruff check .
+pytest
+```
+
 ## データ入出力画面の管理パスワード設定
 
 設定 > データ入出力では、テンプレートのダウンロードや大量のデータ更新が可能なため、管理パスワードによる保護が必要です。以下のいずれかの方法で `DATA_IO_PASSWORD` を設定してください。

--- a/law_updates.py
+++ b/law_updates.py
@@ -9,12 +9,16 @@ import re
 import time
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Any, Callable, Dict, Iterable, List, Optional, Sequence
+from typing import TYPE_CHECKING, Any, Callable, Dict, Iterable, List, Optional, Sequence
 
 import pandas as pd
 import requests
 
 logger = logging.getLogger(__name__)
+
+
+if TYPE_CHECKING:
+    from app import DBManager
 
 
 def re_split(text: str) -> List[str]:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,6 @@
+[tool.ruff]
+line-length = 100
+target-version = "py311"
+
+[tool.ruff.lint]
+select = ["E9", "F63", "F7", "F82"]

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,3 +8,5 @@ openpyxl
 rapidfuzz
 requests
 spacy
+pytest
+ruff

--- a/tests/test_app_startup.py
+++ b/tests/test_app_startup.py
@@ -1,0 +1,82 @@
+"""Streamlit app startup behaviour tests."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pandas as pd
+from sqlalchemy import create_engine
+from streamlit.testing.v1 import AppTest
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+import app
+
+
+def test_main_navigation_flow(monkeypatch, tmp_path):
+    engine = create_engine(f"sqlite:///{tmp_path / 'takken.db'}", future=True)
+    app.metadata.create_all(engine)
+
+    monkeypatch.setattr(app, "get_engine", lambda: engine)
+    monkeypatch.setattr(app, "apply_user_preferences", lambda: None)
+
+    fake_df = pd.DataFrame(
+        {
+            "id": ["q-2023-1"],
+            "year": [2023],
+            "q_no": [1],
+            "category": ["民法"],
+            "question": ["宅建業法の定義は?"],
+        }
+    )
+    monkeypatch.setattr(app, "load_questions_df", lambda: fake_df)
+
+    render_calls: list[str] = []
+
+    def _record(name: str):
+        def _inner(*_args, **_kwargs) -> None:
+            render_calls.append(name)
+
+        return _inner
+
+    class FakeDB:
+        def __init__(self, _engine) -> None:
+            self.engine = _engine
+            self.initialized = False
+
+        def initialize_from_csv(self) -> None:
+            self.initialized = True
+
+    created_dbs: list[FakeDB] = []
+
+    def fake_db_manager(engine_arg):
+        db = FakeDB(engine_arg)
+        created_dbs.append(db)
+        return db
+
+    monkeypatch.setattr(app, "DBManager", fake_db_manager)
+    monkeypatch.setattr(app, "render_learning", _record("学習"))
+    monkeypatch.setattr(app, "render_mock_exam", _record("模試"))
+    monkeypatch.setattr(app, "render_stats", _record("統計"))
+    monkeypatch.setattr(app, "render_settings", _record("設定"))
+
+    def run_app():
+        import app as app_module
+
+        app_module.main()
+
+    app_test = AppTest.from_function(run_app)
+    app_test.run()
+
+    assert created_dbs and all(db.initialized for db in created_dbs)
+    assert render_calls[-1] == "学習"
+
+    menu = app_test.sidebar.radio[0]
+    menu.set_value("設定")
+    app_test.run()
+
+    assert render_calls[-1] == "設定"
+    assert app_test.session_state["nav"] == "設定"

--- a/tests/test_data_io.py
+++ b/tests/test_data_io.py
@@ -1,0 +1,182 @@
+"""Tests for data import and loading helpers."""
+
+from __future__ import annotations
+
+import sys
+import textwrap
+from pathlib import Path
+
+import pandas as pd
+from sqlalchemy import create_engine, insert
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+import app
+
+
+class DummyUploadedFile:
+    """Simple stand-in for ``streamlit`` uploaded files."""
+
+    def __init__(self, name: str, data: bytes) -> None:
+        self.name = name
+        self._data = data
+
+    def getvalue(self) -> bytes:
+        return self._data
+
+
+class StreamlitStub:
+    """Minimal stub that captures Streamlit status messages."""
+
+    def __init__(self) -> None:
+        self.messages: list[tuple[str, str]] = []
+        self.session_state: dict[str, str] = {}
+
+    @staticmethod
+    def expander(*_args, **_kwargs):
+        class _Expander:
+            def __enter__(self):
+                return self
+
+            def __exit__(self, _exc_type, _exc, _tb) -> bool:
+                return False
+
+        return _Expander()
+
+    def warning(self, message: str) -> None:
+        self.messages.append(("warning", str(message)))
+
+    def error(self, message: str) -> None:
+        self.messages.append(("error", str(message)))
+
+    def info(self, message: str) -> None:
+        self.messages.append(("info", str(message)))
+
+    def success(self, message: str) -> None:
+        self.messages.append(("success", str(message)))
+
+    @staticmethod
+    def markdown(*_args, **_kwargs) -> None:
+        return None
+
+    @staticmethod
+    def dataframe(*_args, **_kwargs) -> None:
+        return None
+
+    @staticmethod
+    def caption(*_args, **_kwargs) -> None:
+        return None
+
+
+def build_sample_csvs(base_dir: Path) -> None:
+    questions_csv = textwrap.dedent(
+        """
+        year,q_no,category,topic,question,choice1,choice2,choice3,choice4,explanation,difficulty,tags
+        2023,1,民法,基礎,宅建業法の定義は?,宅建士,宅地,建物,その他,詳しい説明,3,重要
+        """
+    ).strip()
+    answers_csv = textwrap.dedent(
+        """
+        year,q_no,correct_number,correct_label,correct_text,explanation
+        2023,1,1,A,宅建士,正しい選択肢
+        """
+    ).strip()
+    (base_dir / "questions.csv").write_text(questions_csv, encoding="utf-8")
+    (base_dir / "answers.csv").write_text(answers_csv, encoding="utf-8")
+
+
+def test_initialize_from_csv_imports_questions(tmp_path, monkeypatch):
+    data_dir = tmp_path / "import_data"
+    data_dir.mkdir()
+    build_sample_csvs(data_dir)
+
+    engine = create_engine(f"sqlite:///{tmp_path / 'takken.db'}", future=True)
+    app.metadata.create_all(engine)
+
+    monkeypatch.setattr(app, "DATA_DIR", data_dir)
+    monkeypatch.setattr(app, "rebuild_tfidf_cache", lambda: None)
+
+    db = app.DBManager(engine)
+    db.initialize_from_csv()
+
+    imported = db.load_dataframe(app.questions_table)
+    assert len(imported) == 1
+    row = imported.iloc[0]
+    assert row["question"].startswith("宅建業法")
+    assert row["correct"] == 1
+
+
+def test_execute_quick_import_merges_and_reports(monkeypatch):
+    stub = StreamlitStub()
+    monkeypatch.setattr(app, "st", stub)
+
+    rebuild_calls: list[None] = []
+    monkeypatch.setattr(app, "rebuild_tfidf_cache", lambda: rebuild_calls.append(None))
+
+    class DummyDB:
+        def __init__(self) -> None:
+            self.upserted_df: pd.DataFrame | None = None
+
+        def upsert_questions(self, df: pd.DataFrame) -> tuple[int, int]:
+            self.upserted_df = df
+            return len(df), 0
+
+    questions_file = DummyUploadedFile(
+        "questions.csv",
+        textwrap.dedent(
+            """
+            year,q_no,category,topic,question,choice1,choice2,choice3,choice4,explanation,difficulty,tags
+            2023,1,民法,基礎,宅建業法の定義は?,宅建士,宅地,建物,その他,詳しい説明,3,重要
+            """
+        ).strip().encode("utf-8"),
+    )
+    answers_file = DummyUploadedFile(
+        "answers.csv",
+        textwrap.dedent(
+            """
+            year,q_no,correct_number,correct_label,correct_text,explanation
+            2023,1,1,A,宅建士,正しい選択肢
+            """
+        ).strip().encode("utf-8"),
+    )
+
+    db = DummyDB()
+    app.execute_quick_import(db, questions_file, answers_file)
+
+    assert db.upserted_df is not None
+    assert len(db.upserted_df) == 1
+    assert any(kind == "success" for kind, _ in stub.messages)
+    assert rebuild_calls, "rebuild_tfidf_cache should be triggered after import"
+
+
+def test_load_questions_df_uses_configured_engine(tmp_path, monkeypatch):
+    engine = create_engine(f"sqlite:///{tmp_path / 'takken.db'}", future=True)
+    app.metadata.create_all(engine)
+    with engine.begin() as conn:
+        conn.execute(
+            insert(app.questions_table),
+            {
+                "id": "q-2023-1",
+                "year": 2023,
+                "q_no": 1,
+                "category": "民法",
+                "topic": "概要",
+                "question": "宅建業法の定義は?",
+                "choice1": "宅建士",
+                "choice2": "宅地",
+                "choice3": "建物",
+                "choice4": "その他",
+                "correct": 1,
+                "explanation": "詳しい説明",
+                "difficulty": 3,
+                "tags": "重要",
+            },
+        )
+
+    monkeypatch.setattr(app, "get_engine", lambda: engine)
+    app.load_questions_df.clear()
+    df = app.load_questions_df()
+    assert not df.empty
+    assert df.iloc[0]["question"] == "宅建業法の定義は?"


### PR DESCRIPTION
## Summary
- add pytest coverage for database import helpers and Streamlit navigation
- configure ruff linting and include dev dependencies
- add a CI workflow that runs linting and pytest, with README guidance for local runs

## Testing
- ruff check .
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68e0c3d8ab8c8323832a6c808c1e9646